### PR TITLE
Fix script exception when filtering by tag

### DIFF
--- a/src/UI_Tags.as
+++ b/src/UI_Tags.as
@@ -255,14 +255,14 @@ bool TrackMatchesTagsFilters(TmxMapInfo@ info) {
     if (info is null || info.TagList.Length == 0) return false;
     if (g_TrackTagsModeExclusive) {
         for (uint i = 0; i < info.TagList.Length; i++) {
-            if (info.TagList[i] - 1 < int(tags.Length)) {
+            if (info.TagList[i] > 0 && info.TagList[i] - 1 < int(tags.Length)) {
                 if (!tags[info.TagList[i] - 1].checked) return false;
             }
         }
         return true;
     } else {
         for (uint i = 0; i < info.TagList.Length; i++) {
-            if (info.TagList[i] - 1 < int(tags.Length)) {
+            if (info.TagList[i] > 0 && info.TagList[i] - 1 < int(tags.Length)) {
                 if (tags[info.TagList[i] - 1].checked) return true;
             } else {
                 // trace(tostring(info.TagList[i]));

--- a/src/codegen/TmxMapInfo.as
+++ b/src/codegen/TmxMapInfo.as
@@ -9,8 +9,11 @@ class TmxMapInfo {
   TmxMapInfo(uint TrackID, const string &in Name, MaybeOfString@ Tags, const int[] &in TagList) {
     this._TrackID = TrackID;
     this._Name = Name;
-    @this._Tags = Tags;
-    this._TagList = TagList;
+
+    if (Tags != "") {
+      @this._Tags = Tags;
+      this._TagList = TagList;
+    }
   }
 
   /* Methods // Mixin: ToFrom JSON Object */
@@ -19,10 +22,16 @@ class TmxMapInfo {
     this._Name = string(j["Name"]);
     @this._Tags = MaybeOfString(j["Tags"]);
     auto tagsStr = _Tags.GetOr("");
-    auto tags = tagsStr.Split(",");
-    this._TagList = array<int>(tags.Length);
-    for (uint i = 0; i < tags.Length; i++) {
-      this._TagList[i] = Text::ParseInt(tags[i]);
+
+    if (tagsStr != "") {
+      auto tags = tagsStr.Split(",");
+      this._TagList = array<int>(tags.Length);
+      for (uint i = 0; i < tags.Length; i++) {
+        int tagId;
+        if (Text::TryParseInt(tags[i], tagId) && tagId > 0 && tagId <= NUM_TAGS) {
+          this._TagList[i] = tagId;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
I explained the issue on Discord, but the old TMX endpoints returns an empty string when a map has no tags. For the `TmxMapInfo`, the plugin parses the tags here

https://github.com/XertroV/tm-better-totd/blob/e1a33add5f8f9dc6e3b6e3596557439b74729a6b/src/codegen/TmxMapInfo.as#L21-L26

The issue is that, when it's an empty string, we are still splitting the string, which returns `[""]`. Below that, `Text::ParseInt` will return 0 for an empty string, which doesn't exist as a tag ID. In `TrackMatchesTagsFilters`, there's this check for tag IDs

https://github.com/XertroV/tm-better-totd/blob/e1a33add5f8f9dc6e3b6e3596557439b74729a6b/src/UI_Tags.as#L257-L259

But 0 will pass that check, meaning we are calling `tags[-1]` afterwards, throwing an OOB exception

This PR adds more checks around these parts, which should solve any further issue till the plugin is migrated to the new TMX endpoints