### PR TITLE
Use date as tie breaker

### DIFF
--- a/src/TOTDs.as
+++ b/src/TOTDs.as
@@ -176,33 +176,33 @@ int Less_AuthorName(LazyMap@ m1, LazyMap@ m2) {
     return 0;
 }
 int Less_AuthorTime(LazyMap@ m1, LazyMap@ m2) {
-    if (m1.medals[0] == m2.medals[0]) return 0;
+    if (m1.medals[0] == m2.medals[0]) return Less_NewFirst(m1, m2);
     if (m1.medals[0] <= -1) return 1;
     if (m2.medals[0] <= -1) return -1;
     return Math::Clamp(m1.medals[0] - m2.medals[0], -1, 1);
 }
 int Less_FewestATs(LazyMap@ m1, LazyMap@ m2) {
-    if (m1.AtCount == m2.AtCount) return 0;
+    if (m1.AtCount == m2.AtCount) return Less_NewFirst(m1, m2);
     if (m1.AtCount <= -1) return 1;
     if (m2.AtCount <= -1) return -1;
     return Math::Clamp(m1.AtCount - m2.AtCount, -1, 1);
 }
 int Less_MostATs(LazyMap@ m1, LazyMap@ m2) {
-    if (m1.AtCount == m2.AtCount) return 0;
+    if (m1.AtCount == m2.AtCount) return Less_NewFirst(m1, m2);
     if (m1.AtCount <= -1) return 1;
     if (m2.AtCount <= -1) return -1;
     return Math::Clamp(m2.AtCount - m1.AtCount, -1, 1);
 }
 
 int Less_PB_NewFirst(LazyMap@ m1, LazyMap@ m2) {
-    if (m1.playerRecordTimestamp == m2.playerRecordTimestamp) return 0;
+    if (m1.playerRecordTimestamp == m2.playerRecordTimestamp) return Less_NewFirst(m1, m2);
     if (m1.playerRecordTimestamp <= -1) return 1;
     if (m2.playerRecordTimestamp <= -1) return -1;
     return Math::Clamp(m2.playerRecordTimestamp - m1.playerRecordTimestamp, -1, 1);
 }
 
 int Less_PB_OldFirst(LazyMap@ m1, LazyMap@ m2) {
-    if (m1.playerRecordTimestamp == m2.playerRecordTimestamp) return 0;
+    if (m1.playerRecordTimestamp == m2.playerRecordTimestamp) return Less_NewFirst(m1, m2);
     if (m1.playerRecordTimestamp <= -1) return 1;
     if (m2.playerRecordTimestamp <= -1) return -1;
     return Math::Clamp(m1.playerRecordTimestamp - m2.playerRecordTimestamp, -1, 1);


### PR DESCRIPTION
When comparing TOTDs, certain sorting methods can result on ties, like AT count or PB timestamp. This can cause an issue when filtering, where maps change order randomly each time you change a filter

Before:

https://github.com/user-attachments/assets/a85e1dcd-2ecf-4ad9-a4b6-05f54a2fb88d

After:

https://github.com/user-attachments/assets/2ee9d440-509e-46f4-bd87-48587b45cf26



