### PR TITLE
migrate at count functionality to @socramdavid site

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features:
 * Filter TOTDs by date, medals, author, track name, TMX tags.
 * Sort by date, PB date, track name, author name, # ATs.
 * Auto-load new TOTDs the second they become available.
-* Integration with [Author-Tracker.com](https://author-tracker.com).
+* Integration with [Author-Tracker.socr.am](https://author-tracker.socr.am).
 * Quick buttons for tm.io and TMX.
 * Great UI & Instant PB loading.
 

--- a/src/tabs/About.as
+++ b/src/tabs/About.as
@@ -66,7 +66,7 @@ namespace About {
 
     void UtilButtons() {
         if (UI::Button("Your Author Tracker rank: " + AuthorTracker::PlayersRanking())) {
-            OpenBrowserURL("https://www.author-tracker.com/player/" + LocalAccountId);
+            OpenBrowserURL("https://www.author-tracker.socr.am");
         }
     }
 

--- a/src/tabs/AuthorTracker.as
+++ b/src/tabs/AuthorTracker.as
@@ -58,14 +58,10 @@ namespace AuthorTracker {
         }
     }
 
-    const string UrlForGetPlayersInfo(const string &in wsid) {
-        return "https://www.author-tracker.com/api/v1/player/" + wsid;
-    }
-
     int nbReqs = 0;
     string lastGetPlayersInfoRaw;
     Json::Value@ GetPlayersInfo(const string &in wsid) {
-        string url = "https://www.author-tracker.com/api/v1/player/" + wsid;
+        string url = "https://author-tracker.socr.am/api/nadeo/totdAtCount";
         auto req = PluginGetRequest(url);
         nbReqs++;
         req.Start();
@@ -76,7 +72,7 @@ namespace AuthorTracker {
             return GetPlayersInfo(SPAMS_WSID);
         }
         if (req.ResponseCode() >= 400 || req.Error().Length > 0) {
-            log_warn("Failed to get player info from author-tracker.com. Error: " + req.Error());
+            log_warn("Failed to get player info from author-tracker.socr.am. Error: " + req.Error());
             return null;
         }
         lastGetPlayersInfoRaw = req.String();
@@ -112,7 +108,7 @@ namespace AuthorTracker {
     }
 
     const string PlayersRanking() {
-        if (data is null) return "Unknown";
+        if (data is null) return "Coming soon...";
         try {
             if (string(data.Get('player').Get('id')) != LocalAccountId) {
                 return "Unranked";
@@ -120,7 +116,7 @@ namespace AuthorTracker {
             return tostring(int(data.Get('rank')));
 
         } catch {}
-        return "Unknown";
+        return "Coming soon...";
     }
 
     void DrawTab() {


### PR DESCRIPTION
author-tracker website has been down for a while, so I am remaking it. First thing I did was remake the at count per map functionality, which is hosted now at https://author-tracker.socr.am/api/nadeo/totdAtCount. Structure of data returned is the same, so just replacing the url works (it contains all maps so no need to use a player with the most ATs possible). 

I don't have files from previous version, so would be nice if you can test using this version while having old files in pluginstorage. 

I will add leaderboard on my side soon so I will open a new PR with that soon 